### PR TITLE
Fix code scanning alert no. 1: Incomplete regular expression for hostnames

### DIFF
--- a/utils/passes_api.py
+++ b/utils/passes_api.py
@@ -235,7 +235,7 @@ class PassesAPI:
             page = await browser.new_page()
 
             async with page.expect_response(
-                re.compile("https://www.google.com/recaptcha/enterprise/anchor")
+                re.compile(r"https://www\.google\.com/recaptcha/enterprise/anchor")
             ) as response_info:
                 await page.goto("https://www.passes.com/login")
                 await page.get_by_test_id("email").fill(email)


### PR DESCRIPTION
Fixes [https://github.com/Xewdy444/PassesDL/security/code-scanning/1](https://github.com/Xewdy444/PassesDL/security/code-scanning/1)

To fix the problem, we need to escape the `.` characters in the regular expression to ensure that they match only literal `.` characters and not any character. This can be done by using a raw string (`r""`) and escaping each `.` with a backslash (`\.`).

- Change the regular expression on line 238 to escape the `.` characters.
- Ensure that the functionality remains the same by matching the exact URL `https://www.google.com/recaptcha/enterprise/anchor`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
